### PR TITLE
Add exception handling for unregister_plugin

### DIFF
--- a/djangocms_bootstrap5/contrib/bootstrap5_link/cms_plugins.py
+++ b/djangocms_bootstrap5/contrib/bootstrap5_link/cms_plugins.py
@@ -1,3 +1,4 @@
+from cms.exceptions import PluginNotRegistered
 from django.utils.translation import gettext_lazy as _
 
 from cms.plugin_pool import plugin_pool
@@ -78,5 +79,8 @@ class Bootstrap5LinkPlugin(LinkPlugin):
         )
 
 
-plugin_pool.unregister_plugin(LinkPlugin)
+try:
+    plugin_pool.unregister_plugin(LinkPlugin)
+except PluginNotRegistered:
+    pass
 plugin_pool.register_plugin(Bootstrap5LinkPlugin)

--- a/djangocms_bootstrap5/contrib/bootstrap5_picture/cms_plugins.py
+++ b/djangocms_bootstrap5/contrib/bootstrap5_picture/cms_plugins.py
@@ -1,5 +1,6 @@
 import copy
 
+from cms.exceptions import PluginNotRegistered
 from django.utils.translation import gettext_lazy as _
 
 from cms.plugin_pool import plugin_pool
@@ -51,5 +52,8 @@ class Bootstrap5PicturePlugin(PicturePlugin):
         )
 
 
-plugin_pool.unregister_plugin(PicturePlugin)
+try:
+    plugin_pool.unregister_plugin(PicturePlugin)
+except PluginNotRegistered:
+    pass
 plugin_pool.register_plugin(Bootstrap5PicturePlugin)


### PR DESCRIPTION
This handles  ```PluginNotRegistered``` that is raised if ```LinkPlugin``` or ```PicturePlugin``` was already removed, e.g. by ```bootstrap4_link``` or ```bootstrap4_picture``.

fix #5 