### PR TITLE
ungettext deprecated since Django 3

### DIFF
--- a/djangocms_bootstrap5/contrib/bootstrap5_grid/models.py
+++ b/djangocms_bootstrap5/contrib/bootstrap5_grid/models.py
@@ -2,7 +2,7 @@ from functools import partial
 
 from django.db import models
 from django.utils.translation import gettext_lazy as _
-from django.utils.translation import ungettext
+from django.utils.translation import gettext
 
 from cms.models import CMSPlugin
 
@@ -86,7 +86,7 @@ class Bootstrap5GridRow(CMSPlugin):
 
     def get_short_description(self):
         column_count = len(self.child_plugin_instances or [])
-        column_count_str = ungettext(
+        column_count_str = gettext(
             '(1 column)',
             '(%(count)i columns)',
             column_count


### PR DESCRIPTION
The u-prefixed functions have been dropped since Django 3. Hence leading to an import error. For more information check out. See https://docs.djangoproject.com/en/3.0/ref/utils/#django.utils.translation.gettext